### PR TITLE
Gestion du format de l'image dans le header

### DIFF
--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -7,3 +7,8 @@ services:
     app.image_uploader:
         class: BLOGBundle\FileUploader
         arguments: ['%image_directory%']
+    twig.extension.imgsize:
+        class: BLOGBundle\Twig\ImgSizeExtension
+        arguments:    [%image_directory%]
+        tags:
+            - name: twig.extension

--- a/src/BLOGBundle/Resources/views/User/index.html.twig
+++ b/src/BLOGBundle/Resources/views/User/index.html.twig
@@ -2,20 +2,25 @@
 
 {% block section %}
     <section>
-		{% for article in articles %}
-			{% if loop.first %}
-				{% for image in article.image %}
-					{% if loop.first %}
-						<img src="{{ asset('bundles/images/'~image.src)}}"/>
-					{% endif %}
-				{% endfor %}
-				<figcaption class="picture-caption">
-					<h2> {{ article.title }} </h2>
-					<a href='{{ path('blog_article', {id : article.id}) }}'><button class="btn btn-custom btn-danger">En savoir plus</button></a>
-					<i> Publié le {{ article.date.date|date('d/m/Y') }}</i>
-				</figcaption>
-			{% endif %}
-		{% endfor %}
+        {% set breack = false %}
+        {% if breack == false %}
+            {% for article in articles %}
+                {% if breack == false %}
+                    {% for image in article.image %}
+                        {% set size = imgsize(image.src) %}
+                        {% if size.width >= size.height %}
+                            {% set breack = true %}
+                            <img src="{{ asset('bundles/images/'~image.src)}}"/>
+                        {% endif %}
+                    {% endfor %}
+                {% endif %}
+                <figcaption class="picture-caption">
+                    <h2> {{ article.title }} </h2>
+                    <a href='{{ path('blog_article', {id : article.id}) }}'><button class="btn btn-custom btn-danger">En savoir plus</button></a>
+                    <i> Publié le {{ article.date.date|date('d/m/Y') }}</i>
+                </figcaption>
+            {% endfor %}
+        {% endif %}
     </section>
 {% endblock %}
 

--- a/src/BLOGBundle/Twig/ImgSizeExtension.php
+++ b/src/BLOGBundle/Twig/ImgSizeExtension.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace BLOGBundle\Twig;
+
+class ImgSizeExtension extends \Twig_Extension
+{
+    protected $param;
+
+    public function __construct($param)
+    {
+        $this->param = $param;
+    }
+
+    public function getFunctions()
+    {
+        return array(
+            new \Twig_SimpleFunction('imgsize', array($this, 'imgWidth'))
+        );
+    }
+
+    public function imgWidth($img)
+    {
+        $data = getimagesize($this->param . '/' . $img);
+        $size = ['width' => $data[0], 'height' => $data[1]];
+        return $size;
+    }
+
+    public function getName()
+    {
+        return 'imgsize';
+    }
+}


### PR DESCRIPTION
1. Ajout d'une extension Twig permettant de récupérer la width et la
height d'une image directement dans la vue.
Ex:
```{{ imgsize(mon_image.jpg) }}``` renvéra ```array('width' => 12,
'height' => 23)```
Extension ==> *src/BLOGBundle/Twig/ImgSizeExtension.php*
Déclaration de l'extension: *app/config/service.yml*
2. Modification du template *src/BLOGBundle/Resources/views/User/index.html.twig*
Modification de la boucle, on affiche l'image uniquement si elle est en
landscape, sinon on regarde les autres images, si pas d'image dans
l'article, on va voir dans un autre article (du plus récent au plus
ancien)